### PR TITLE
fix: ensure signing client is only retrieved when wallet is connected

### DIFF
--- a/packages/react/src/hooks/useSigningClient.ts
+++ b/packages/react/src/hooks/useSigningClient.ts
@@ -11,7 +11,10 @@ export const useSigningClient = (chainName: string, walletName: string) => {
     queryKey: `signing-client-${chainName}-${walletName}`,
     queryFn: async () => {
       await getRpcEndpoint(walletName, chainName)
-      return getSigningClient(walletName, chainName)
+      const currentWalletState = getChainWalletState(walletName, chainName)?.walletState;
+      if(currentWalletState === WalletState.Connected) {
+        return getSigningClient(walletName, chainName);
+      }
     },
     enabled: chainWalletState?.walletState === WalletState.Connected,
     disableCache: true,


### PR DESCRIPTION
## Description

### Steps To Reproduce

1. open https://interchain-kit-repro.vercel.app/ with a browser with keplr extension,
(or run this code - https://github.com/2wheeh/interchain-kit-repro)
2. connect
3. reload - this would disconnect directly on purpose but the app still opens a modal by `getSigningClient` call

### Issue Details

it shouldn't call `getSingingClient` when the wallet is disconnected.
however `await getRpcEndpoint(walletName, chainName)` takes some time to resolve (approx. 400ms).
so, when the wallet gets disconnected between the time `queryFn` fires and `getRpcEndpoint()` is done, the bug occurs.

### Solution
adds a check for the current connection states before `getSigningClient` call

## Test Plan

### Before

https://github.com/user-attachments/assets/f6c50512-161c-42e9-bd32-87c7136f9492

### After

https://github.com/user-attachments/assets/bf805a7c-11e3-4797-b927-3082dec36ca3


